### PR TITLE
Change regex to also match resource declaration if resource name cont…

### DIFF
--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -24,7 +24,7 @@ patterns:
       name: string.value.terraform
     '4':
       name: punctuation.definition.tag.terraform
-  match: (resource) "(\w+)" "(\w+)" ({)
+  match: (resource) "(\w+)" "(.+)" ({)
 
 # Provider-like blocks (one variable)
 - captures:


### PR DESCRIPTION
…ains not only word char - hyphens etc.

This is not ideal as it would also accept some weird combinations with other non word characters but they are less likely to occur than hyphens which are quite common.