### PR TITLE
More syntax highlighting

### DIFF
--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -14,6 +14,19 @@ patterns:
   match: ^(\s)*(#).*$\n?
   name: comment.line.hash.ini
 
+# Language constants
+- comment: Language constants (true, false, yes, no, on, off)
+  match: \b(true|false|yes|no|on|off)\b
+  name: constant.language.terraform
+
+# Numeric types
+- comment: Numbers
+  match: \b([0-9]+)([kKmMgG]b?)?\b
+  name: constant.numeric.terraform
+- comment: Hex numbers
+  match: \b(0x[0-9A-Fa-f]+)([kKmMgG]b?)?\b
+  name: constant.numeric.terraform
+
 # Resource blocks (two variables)
 - captures:
     '1':

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -82,3 +82,15 @@ patterns:
     '4':
       name: keyword.operator.terraform
   match: (")([\w_-]+)(")\s*(=)\s*
+
+# Strings
+- comment: Strings
+  name: string.quoted.double.terraform
+  begin: \"
+  end: \"
+  beginCaptures:
+    "0":
+      name: punctuation.definition.string.begin.terraform
+  endCaptures:
+    "0":
+      name: punctuation.definition.string.end.terraform

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -6,13 +6,14 @@ fileTypes: ['tf']
 uuid: 9060ca81-906d-4f19-a91a-159f4eb119d6
 
 patterns:
-
 # Comments
-- captures:
-    '1':
+- comment: Comments
+  name: comment.line.number-sign.terraform
+  begin: "#"
+  end: $\n?
+  captures:
+    "0":
       name: punctuation.definition.comment.terraform
-  match: ^(\s)*(#).*$\n?
-  name: comment.line.hash.ini
 
 # Language constants
 - comment: Language constants (true, false, yes, no, on, off)

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -83,6 +83,15 @@ patterns:
       name: keyword.operator.terraform
   match: (")([\w_-]+)(")\s*(=)\s*
 
+# Maps
+- comment: Maps
+  captures:
+    '1':
+      name: entity.name.section.terraform
+    '2':
+      name: punctuation.definition.tag.terraform
+  match: ([\w\-_]+)\s+({)
+
 # Strings
 - comment: Strings
   name: string.quoted.double.terraform

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -63,16 +63,22 @@ patterns:
       name: punctuation.definition.tag.terraform
   match: (provider|provisioner|variable|output|module|atlas)\s+(")([\w-]+)(")\s+({)
 
-# Basic x = "y" matching
-- captures:
+# Value assignments
+- comment: Value assignments (left hand side not in double quotes)
+  captures:
     '1':
       name: variable.assignment.terraform
     '2':
       name: keyword.operator.terraform
+  match: ([\w_-]+)\s*(=)\s*
+- comment: Value assignments (left hand side in double quotes)
+  captures:
+    '1':
+      name: punctuation.quote.double.terraform
+    '2':
+      name: variable.assignment.terraform
     '3':
       name: punctuation.quote.double.terraform
     '4':
-      name: string.value.terraform
-    '5':
-      name: punctuation.quote.double.terraform
-  match: ([\w_-]+)\s+(=)\s(")(.+)(\3)
+      name: keyword.operator.terraform
+  match: (")([\w_-]+)(")\s*(=)\s*

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -2,7 +2,7 @@
 ---
 name: Terraform
 scopeName: source.terraform
-fileTypes: ['tf']
+fileTypes: ['tf', 'tfvars']
 uuid: 9060ca81-906d-4f19-a91a-159f4eb119d6
 
 patterns:

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -53,10 +53,14 @@ patterns:
     '1':
       name: storage.type.function.terraform
     '2':
-      name: string.value.terraform
+      name: punctuation.definition.string.begin.terraform
     '3':
+      name: string.value.terraform
+    '4':
+      name: punctuation.definition.string.end.terraform
+    '5':
       name: punctuation.definition.tag.terraform
-  match: (provider|provisioner|variable|output|module|atlas) "([\w-]+)" ({)
+  match: (provider|provisioner|variable|output|module|atlas)\s+(")([\w-]+)(")\s+({)
 
 # Basic x = "y" matching
 - captures:

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -32,12 +32,21 @@ patterns:
     '1':
       name: storage.type.function.terraform
     '2':
-      name: string.value.terraform
+      name: punctuation.definition.string.begin.terraform
     '3':
       name: string.value.terraform
     '4':
+      name: punctuation.definition.string.end.terraform
+    '5':
+      name: punctuation.definition.string.begin.terraform
+    '6':
+      name: string.value.terraform
+    '7':
+      name: punctuation.definition.string.end.terraform
+    '8':
       name: punctuation.definition.tag.terraform
-  match: (resource) "(\w+)" "(.+)" ({)
+  match: (resource)\s+(")(\w+)(")\s+(")(.+)(")\s+({)
+  name: meta.resource.terraform
 
 # Provider-like blocks (one variable)
 - captures:

--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -1,28 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
 	<array>
 		<string>tf</string>
+		<string>tfvars</string>
 	</array>
 	<key>name</key>
 	<string>Terraform</string>
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>begin</key>
+			<string>#</string>
 			<key>captures</key>
 			<dict>
-				<key>1</key>
+				<key>0</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.comment.terraform</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>^(\s)*(#).*$\n?</string>
+			<key>comment</key>
+			<string>Comments</string>
+			<key>end</key>
+			<string>$\n?</string>
 			<key>name</key>
-			<string>comment.line.hash.ini</string>
+			<string>comment.line.number-sign.terraform</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Language constants (true, false, yes, no, on, off)</string>
+			<key>match</key>
+			<string>\b(true|false|yes|no|on|off)\b</string>
+			<key>name</key>
+			<string>constant.language.terraform</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Numbers</string>
+			<key>match</key>
+			<string>\b([0-9]+)([kKmMgG]b?)?\b</string>
+			<key>name</key>
+			<string>constant.numeric.terraform</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Hex numbers</string>
+			<key>match</key>
+			<string>\b(0x[0-9A-Fa-f]+)([kKmMgG]b?)?\b</string>
+			<key>name</key>
+			<string>constant.numeric.terraform</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -35,7 +64,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>string.value.terraform</string>
+					<string>punctuation.definition.string.begin.terraform</string>
 				</dict>
 				<key>3</key>
 				<dict>
@@ -45,11 +74,33 @@
 				<key>4</key>
 				<dict>
 					<key>name</key>
+					<string>punctuation.definition.string.end.terraform</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.terraform</string>
+				</dict>
+				<key>6</key>
+				<dict>
+					<key>name</key>
+					<string>string.value.terraform</string>
+				</dict>
+				<key>7</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.terraform</string>
+				</dict>
+				<key>8</key>
+				<dict>
+					<key>name</key>
 					<string>punctuation.definition.tag.terraform</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(resource) "(\w+)" "(\w+)" ({)</string>
+			<string>(resource)\s+(")(\w+)(")\s+(")(.+)(")\s+({)</string>
+			<key>name</key>
+			<string>meta.resource.terraform</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -62,16 +113,26 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>string.value.terraform</string>
+					<string>punctuation.definition.string.begin.terraform</string>
 				</dict>
 				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>string.value.terraform</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.terraform</string>
+				</dict>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.tag.terraform</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(provider|provisioner|variable|output|module|atlas) "([\w-]+)" ({)</string>
+			<string>(provider|provisioner|variable|output|module|atlas)\s+(")([\w-]+)(")\s+({)</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -86,6 +147,25 @@
 					<key>name</key>
 					<string>keyword.operator.terraform</string>
 				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Value assignments (left hand side not in double quotes)</string>
+			<key>match</key>
+			<string>([\w_-]+)\s*(=)\s*</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.quote.double.terraform</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.assignment.terraform</string>
+				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
@@ -94,16 +174,58 @@
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>string.value.terraform</string>
-				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.quote.double.terraform</string>
+					<string>keyword.operator.terraform</string>
 				</dict>
 			</dict>
+			<key>comment</key>
+			<string>Value assignments (left hand side in double quotes)</string>
 			<key>match</key>
-			<string>([\w_-]+)\s+(=)\s(")(.+)(\3)</string>
+			<string>(")([\w_-]+)(")\s*(=)\s*</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.section.terraform</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.terraform</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Maps</string>
+			<key>match</key>
+			<string>([\w\-_]+)\s+({)</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>\"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.terraform</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Strings</string>
+			<key>end</key>
+			<string>\"</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.terraform</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.quoted.double.terraform</string>
 		</dict>
 	</array>
 	<key>scopeName</key>


### PR DESCRIPTION
I started my own .tmLanguage last night without realizing that there was one already. So I've incorporated the other syntax improvements I added (mainly numbers, maps, and language constants) and made some of yours more robust (it wasn't handling `resource "xxx" "a-b-c-d" {` properly).

Hopefully you guys like the improved highlighting :).