### PR TITLE
Add support for double slash comments

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -28,6 +28,12 @@
 					<key>value</key>
 					<string>*/</string>
 			 </dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_3</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
 		</array>
 	</dict>
 	<key>uuid</key>

--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -7,7 +7,7 @@ uuid: 9060ca81-906d-4f19-a91a-159f4eb119d6
 patterns:
 - comment: Comments
   name: comment.line.number-sign.terraform
-  begin: '#'
+  begin: '#|//'
   end: $\n?
   captures:
     '0': {name: punctuation.definition.comment.terraform}

--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -13,7 +13,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>#</string>
+			<string>#|//</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
According to https://github.com/hashicorp/hcl/blob/master/README.md
single line comments can also start with `//`

