### PR TITLE
Add .hcl as a highlighted file extention

### DIFF
--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -1,7 +1,7 @@
 # [PackageDev] target_format: plist, ext: tmLanguage
 name: Terraform
 scopeName: source.terraform
-fileTypes: [tf, tfvars]
+fileTypes: [tf, tfvars, hcl]
 uuid: 9060ca81-906d-4f19-a91a-159f4eb119d6
 
 patterns:

--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -6,6 +6,7 @@
 	<array>
 		<string>tf</string>
 		<string>tfvars</string>
+		<string>hcl</string>
 	</array>
 	<key>name</key>
 	<string>Terraform</string>


### PR DESCRIPTION
Many other Hashicorp tools use the same syntax as terraform files, and thus could use the same syntax highlighting.  I've added 1 additional file extension to include those files.