### PR TITLE
Add support to all built-in functions available on Terraform v0.10.3

### DIFF
--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -104,7 +104,7 @@ repository:
 
   string_interpolation_functions:
     comment: Builtin functions
-    begin: (base64decode|base64encode|base64sha256|ceil|cidrnetmask|compact|distinct|file|floor|keys|length|lower|md5|pathexpand|replace|sha1|sha256|signum|sort|timestamp|title|trimspace|upper|uuid|values|cidrhost|cidrsubnet|coalesce|concat|element|format|formatlist|from|index|join|jsonencode|length|list|lookup|map|max|merge|min|slice|split|substr|zipmap)(\()
+    begin: (base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|ceil|chomp|cidrhost|cidrnetmask|cidrsubnet|coalesce|coalescelist|compact|concat|contains|dirname|distinct|element|file|flatten|floor|format|formatlist|index|join|jsonencode|keys|length|list|log|lookup|lower|map|matchkeys|max|md5|merge|min|pathexpand|pow|replace|sha1|sha256|sha512|signum|slice|sort|split|substr|timestamp|title|trimspace|upper|urlencode|uuid|values|zipmap)(\()
     beginCaptures:
       '1': {name: keyword.other.function.inline.terraform}
       '2': {name: keyword.other.section.begin.terraform}

--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -328,7 +328,7 @@
 		<key>string_interpolation_functions</key>
 		<dict>
 			<key>begin</key>
-			<string>(base64decode|base64encode|base64sha256|ceil|cidrnetmask|compact|distinct|file|floor|keys|length|lower|md5|pathexpand|replace|sha1|sha256|signum|sort|timestamp|title|trimspace|upper|uuid|values|cidrhost|cidrsubnet|coalesce|concat|element|format|formatlist|from|index|join|jsonencode|length|list|lookup|map|max|merge|min|slice|split|substr|zipmap)(\()</string>
+			<string>(base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|ceil|chomp|cidrhost|cidrnetmask|cidrsubnet|coalesce|coalescelist|compact|concat|contains|dirname|distinct|element|file|flatten|floor|format|formatlist|index|join|jsonencode|keys|length|list|log|lookup|lower|map|matchkeys|max|md5|merge|min|pathexpand|pow|replace|sha1|sha256|sha512|signum|slice|sort|split|substr|timestamp|title|trimspace|upper|urlencode|uuid|values|zipmap)(\()</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Full list on:
https://www.terraform.io/docs/configuration/interpolation.html#built-in-functions

Summary of changes:

**ADDED**

```
base64gzip
base64sha512
basename
bcrypt
chomp
coalescelist
contains
dirname
flatten
log
matchkeys
pow
sha512
urlencode
```

**REMOVED**

```
from     # This is not a built-in function. Not sure why it was defined
length   # was defined twice
```
