### PR TITLE
Syntax Highlight Correction for Regex's inside strings (See Issue #28)

### DIFF
--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -364,6 +364,10 @@
 					<key>include</key>
 					<string>#string_interpolation_keywords</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strings</string>
+				</dict>
 			</array>
 		</dict>
 		<key>string_interpolation_keywords</key>

--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -411,7 +411,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>([\w\-\/\._\\%]+)</string>
+					<string>([\w\-\/\._\\%\(\)]+)</string>
 					<key>name</key>
 					<string>string.quoted.double.terraform</string>
 				</dict>


### PR DESCRIPTION
This should address the following issue:

https://github.com/alexlouden/Terraform.tmLanguage/issues/28

I can't be sure there aren't any side-effects, but locally tested as I also experienced this shows nothing out of the ordinary that I can see.

Recommend Squash-Merge, to avoid my lame commit messages.