### PR TITLE
Minor fixes

### DIFF
--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -102,7 +102,7 @@ contexts:
             0: keyword.control.period.terraform
         - include: strings
   string_interpolation_functions:
-    - match: (base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|ceil|chomp|cidrhost|cidrnetmask|cidrsubnet|coalesce|coalescelist|compact|concat|contains|dirname|distinct|element|file|flatten|floor|format|formatlist|index|join|jsonencode|keys|length|list|log|lookup|lower|map|matchkeys|max|md5|merge|min|pathexpand|pow|replace|sha1|sha256|sha512|signum|slice|sort|split|substr|timestamp|title|trimspace|upper|urlencode|uuid|values|zipmap)(\()
+    - match: (abs|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|list|log|lookup|lower|map|matchkeys|max|md5|merge|min|pathexpand|pow|range|replace|reverse|rsadecrypt|setintersection|setproduct|setunion|sha1|sha256|sha512|signum|slice|sort|split|strrev|substr|templatefile|timeadd|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trimspace|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)(\()
       comment: Builtin functions
       captures:
         1: keyword.other.function.inline.terraform

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -115,7 +115,7 @@ contexts:
         - include: string_interpolation_functions
         - include: string_interpolation_keywords
   string_interpolation_keywords:
-    - match: '(terraform|var|self|count|module|path|data|local)(\.[\w\*]+)+'
+    - match: '(terraform|var|self|count|module|path|data|local)(\.[\w\-\*]+)+'
       captures:
         0: entity.other.attribute-name.terraform
   strings:


### PR DESCRIPTION
This fixes a small bug which has been annoying me for some time, namely that `data` elements with a dash in their identifier weren't syntax highlighted correctly.

I've also updated the list of functions to contain all the new ones from Terraform 0.12.