### PR TITLE
Add Symbol Indexing

### DIFF
--- a/Symbols.tmPreferences
+++ b/Symbols.tmPreferences
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Symbol List</string>
+   <key>scope</key>
+   <string>
+      <!--
+        Resource matches `resource` and `data` blocks. Block matches `provider`,
+        `provisioner`, `variable`, `output`, `module`, and `atlas` blocks.
+      -->
+      meta.resource.terraform,
+      meta.block.terraform
+   </string>
+   <key>settings</key>
+   <dict>
+      <key>showInSymbolList</key>
+      <integer>1</integer>
+      <key>showInIndexedSymbolList</key>
+      <integer>1</integer>
+      <key>symbolTransformation</key>
+      <string>
+        <!-- Removes trailing whitespace and opening bracket from symbol. -->
+        <![CDATA[/\s*{$//]]>
+      </string>
+   </dict>
+</dict>
+</plist>

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -50,6 +50,7 @@ contexts:
         7: string.terraform punctuation.definition.string.end.terraform
         8: punctuation.definition.tag.terraform
     - match: '(provider|provisioner|variable|output|module|atlas)\s+(")?([\w\-]+)(")?\s+({)'
+      scope: meta.block.terraform
       captures:
         1: storage.type.function.terraform
         2: string.terraform punctuation.definition.string.begin.terraform


### PR DESCRIPTION
Adds symbol indexing for the following types of blocks:

- `resource`
- `data`
- `provider`
- `provisioner`
- `variable`
- `output`
- `module`
- `atlas`

These symbols will now be available for [symbol navigation](http://docs.sublimetext.info/en/latest/reference/symbols.html).

<img width="1343" alt="Screen Shot 2019-08-19 at 11 15 50 PM" src="https://user-images.githubusercontent.com/7366232/63317169-646af880-c2d7-11e9-97b8-ab9319858275.png">

This requires adding a new `meta` scope ` meta.block.terraform` around all blocks — similar to how it was previously done for `resource` and `data` blocks (`meta.resource.terraform`).