### PR TITLE
remove quotes around variable type in snippets

### DIFF
--- a/snippets/variable_empty.sublime-snippet
+++ b/snippets/variable_empty.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 variable "${1:name}" {
-	type = "string"
+	type = string
 	${2:description = "${3:describe your variable}"}
 }
 ]]></content>

--- a/snippets/variable_map.sublime-snippet
+++ b/snippets/variable_map.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 variable "${1:name}" {
-	type = "map"
+	type = map
 	${2:description = "${3:describe your variable}"}
 	default = {
 		${4:key1} = "${5:val1}"

--- a/snippets/variable_string.sublime-snippet
+++ b/snippets/variable_string.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 variable "${1:name}" {
-	type = "string"
+	type = string
 	${2:description = "${3:describe your variable}"}
 	default = "${4:default_value}"
 }


### PR DESCRIPTION
in 0.12 you no longer need to quote variable types, https://www.terraform.io/docs/configuration/variables.html. this pr simply removes the quotes from the variable snippets

![out](https://user-images.githubusercontent.com/672246/87058083-82c23700-c1bc-11ea-9116-5aa9f548f071.gif)
