### PR TITLE
feat: Add nomad configuration support

### DIFF
--- a/Terraform.YAML-tmLanguage
+++ b/Terraform.YAML-tmLanguage
@@ -2,7 +2,7 @@
 ---
 name: Terraform
 scopeName: source.terraform
-fileTypes: [tf, tfvars, hcl]
+fileTypes: [tf, tfvars, hcl, nomad]
 uuid: 9060ca81-906d-4f19-a91a-159f4eb119d6
 
 patterns:

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -25,6 +25,7 @@ name: Terraform
 file_extensions:
   - tf
   - hcl
+  - nomad
 scope: source.terraform
 
 variables:

--- a/Terraform.tmLanguage
+++ b/Terraform.tmLanguage
@@ -7,6 +7,7 @@
 		<string>tf</string>
 		<string>tfvars</string>
 		<string>hcl</string>
+		<string>nomad</string>
 	</array>
 	<key>name</key>
 	<string>Terraform</string>


### PR DESCRIPTION
Nomad files are configured against HCL too, this adds sublime text support for them. 