### PR TITLE
github: bump linux version to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Run syntax_tests (${{ matrix.st.name }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         st:


### PR DESCRIPTION
An attempt to get the CI "unstuck", as suggested in https://github.com/alexlouden/Terraform.tmLanguage/pull/56#issuecomment-1898018046